### PR TITLE
fix: resolve TypeScript verbatimModuleSyntax import errors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import { CartProvider } from './contexts/CartContext';

--- a/frontend/src/components/Cart/CartSidebar.tsx
+++ b/frontend/src/components/Cart/CartSidebar.tsx
@@ -53,7 +53,7 @@ const CartSidebar: React.FC<CartSidebarProps> = ({ isOpen, onClose }) => {
             ) : (
               <div className="space-y-4">
                 {items.map((item) => (
-                  <div key={item.product._id || item.product.id} className="flex items-center space-x-4 p-4 border border-cosmic-cyan border-opacity-20 rounded-cyber">
+                  <div key={item.product.id} className="flex items-center space-x-4 p-4 border border-cosmic-cyan border-opacity-20 rounded-cyber">
                     <img
                       src={item.product.imageUrl || '/images/placeholder.jpg'}
                       alt={item.product.name}
@@ -67,14 +67,14 @@ const CartSidebar: React.FC<CartSidebarProps> = ({ isOpen, onClose }) => {
                       <p className="text-cosmic-energy">${item.product.price}</p>
                       <div className="flex items-center space-x-2 mt-2">
                         <button
-                          onClick={() => updateQuantity(item.product._id || item.product.id, item.quantity - 1)}
+                          onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
                           className="w-6 h-6 bg-cosmic-space border border-cosmic-cyan text-cosmic-cyan rounded text-sm hover:bg-cosmic-cyan hover:text-cosmic-void"
                         >
                           -
                         </button>
                         <span className="text-cosmic-cyan">{item.quantity}</span>
                         <button
-                          onClick={() => updateQuantity(item.product._id || item.product.id, item.quantity + 1)}
+                          onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
                           className="w-6 h-6 bg-cosmic-space border border-cosmic-cyan text-cosmic-cyan rounded text-sm hover:bg-cosmic-cyan hover:text-cosmic-void"
                         >
                           +
@@ -82,7 +82,7 @@ const CartSidebar: React.FC<CartSidebarProps> = ({ isOpen, onClose }) => {
                       </div>
                     </div>
                     <button
-                      onClick={() => removeFromCart(item.product._id || item.product.id)}
+                      onClick={() => removeFromCart(item.product.id)}
                       className="text-cosmic-plasma hover:text-cosmic-energy"
                     >
                       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
+import type { ReactNode } from 'react';
 import Header from './Header';
 
 interface LayoutProps {

--- a/frontend/src/components/Products/ProductCard.tsx
+++ b/frontend/src/components/Products/ProductCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useCart } from '../../hooks/useCart';
-import { SuperpowerCapsule, FuturisticMachine } from '../../types';
+import type { SuperpowerCapsule, FuturisticMachine } from '../../types';
 
 interface ProductCardProps {
   product: SuperpowerCapsule | FuturisticMachine;
@@ -42,8 +42,8 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, type }) => {
           }}
         />
         {type === 'capsule' && (
-          <span className={`absolute top-2 right-2 px-2 py-1 rounded text-xs font-bold ${getRarityClass(product.rarity)} border`}>
-            {product.rarity.toUpperCase()}
+          <span className={`absolute top-2 right-2 px-2 py-1 rounded text-xs font-bold ${getRarityClass((product as SuperpowerCapsule).rarity)} border`}>
+            {(product as SuperpowerCapsule).rarity.toUpperCase()}
           </span>
         )}
       </div>
@@ -54,20 +54,20 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, type }) => {
 
         {type === 'capsule' ? (
           <>
-            <p className={`text-sm ${getPowerTypeClass(product.powerType)}`}>
-              {product.superpower}
+            <p className={`text-sm ${getPowerTypeClass((product as SuperpowerCapsule).powerType)}`}>
+              {(product as SuperpowerCapsule).superpower}
             </p>
             <div className="flex items-center justify-between text-sm">
-              <span className="text-cosmic-cyan">Duration: {product.duration}</span>
-              <span className="text-cosmic-energy">Intensity: {product.intensity}/10</span>
+              <span className="text-cosmic-cyan">Duration: {(product as SuperpowerCapsule).duration}</span>
+              <span className="text-cosmic-energy">Intensity: {(product as SuperpowerCapsule).intensity}/10</span>
             </div>
           </>
         ) : (
           <>
-            <p className="text-cosmic-cyan text-sm">{product.model}</p>
+            <p className="text-cosmic-cyan text-sm">{(product as FuturisticMachine).model}</p>
             <div className="flex items-center justify-between text-sm">
-              <span className="text-cosmic-cyan">Type: {product.type}</span>
-              <span className="text-cosmic-energy">Power: {product.specifications.maxPowerOutput}</span>
+              <span className="text-cosmic-cyan">Type: {(product as FuturisticMachine).type}</span>
+              <span className="text-cosmic-energy">Power: {(product as FuturisticMachine).specifications.maxPowerOutput}</span>
             </div>
           </>
         )}
@@ -98,9 +98,9 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, type }) => {
         </div>
 
         {/* Additional Info */}
-        {type === 'capsule' && product.warnings && product.warnings.length > 0 && (
+        {type === 'capsule' && (product as SuperpowerCapsule).warnings && (product as SuperpowerCapsule).warnings.length > 0 && (
           <div className="text-xs text-cosmic-plasma">
-            ⚠️ {product.warnings[0]}
+            ⚠️ {(product as SuperpowerCapsule).warnings[0]}
           </div>
         )}
       </div>

--- a/frontend/src/components/Products/ProductList.tsx
+++ b/frontend/src/components/Products/ProductList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ProductCard from './ProductCard';
-import { SuperpowerCapsule, FuturisticMachine } from '../../types';
+import type { SuperpowerCapsule, FuturisticMachine } from '../../types';
 
 interface ProductListProps {
   products: (SuperpowerCapsule | FuturisticMachine)[];
@@ -60,7 +60,7 @@ const ProductList: React.FC<ProductListProps> = ({
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
         {products.map((product) => (
           <ProductCard
-            key={product._id || product.id}
+            key={product.id}
             product={product}
             type={type}
           />

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
 import { authAPI } from '../services/api';
 
 interface User {
@@ -66,10 +67,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const login = async (email: string, password: string) => {
     try {
-      const response = await authAPI.login(email, password);
+      const response = await authAPI.login(email, password) as { success: boolean; data?: unknown; message?: string };
 
       if (response.success) {
-        const { user, token } = response.data;
+        const { user, token } = response.data as { user: User; token: string };
         localStorage.setItem('authToken', token);
         localStorage.setItem('userData', JSON.stringify(user));
         setUser(user);
@@ -84,10 +85,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const register = async (userData: RegisterUserData) => {
     try {
-      const response = await authAPI.register(userData);
+      const response = await authAPI.register(userData) as { success: boolean; data?: unknown; message?: string };
 
       if (response.success) {
-        const { user, token } = response.data;
+        const { user, token } = response.data as { user: User; token: string };
         localStorage.setItem('authToken', token);
         localStorage.setItem('userData', JSON.stringify(user));
         setUser(user);

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useState, useEffect, ReactNode, useCallback } from 'react';
+import React, { createContext, useState, useEffect, useCallback } from 'react';
+import type { ReactNode } from 'react';
 import { cartAPI } from '../services/api';
-import { SuperpowerCapsule, FuturisticMachine } from '../types';
+import type { SuperpowerCapsule, FuturisticMachine } from '../types';
 
 type Product = SuperpowerCapsule | FuturisticMachine;
 
@@ -52,17 +53,12 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
   const itemCount = items.reduce((sum, item) => sum + item.quantity, 0);
   const total = items.reduce((sum, item) => sum + (item.product.price * item.quantity), 0);
 
-  // Load cart on mount
-  useEffect(() => {
-    loadCart();
-  }, [loadCart]);
-
   const loadCart = useCallback(async () => {
     try {
       setIsLoading(true);
-      const response = await cartAPI.getCart(sessionId);
+      const response = await cartAPI.getCart(sessionId) as { success: boolean; data?: unknown };
       if (response.success) {
-        setItems(response.data || []);
+        setItems((response.data as CartItem[]) || []);
       }
     } catch (error) {
       console.error('Failed to load cart:', error);
@@ -71,17 +67,22 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
     }
   }, [sessionId]);
 
+  // Load cart on mount
+  useEffect(() => {
+    loadCart();
+  }, [loadCart]);
+
   const addToCart = async (product: Product, quantity: number = 1) => {
     try {
       setIsLoading(true);
       const productWithType = {
         ...product,
-        productType: product.superpower ? 'capsule' : 'machine'
+        productType: 'superpower' in product ? 'capsule' : 'machine'
       };
 
-      const response = await cartAPI.addToCart(sessionId, productWithType, quantity);
+      const response = await cartAPI.addToCart(sessionId, productWithType, quantity) as { success: boolean; data?: unknown };
       if (response.success) {
-        setItems(response.data || []);
+        setItems((response.data as CartItem[]) || []);
       }
     } catch (error) {
       console.error('Failed to add to cart:', error);
@@ -94,9 +95,9 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
   const updateQuantity = async (productId: string, quantity: number) => {
     try {
       setIsLoading(true);
-      const response = await cartAPI.updateCart(sessionId, productId, quantity);
+      const response = await cartAPI.updateCart(sessionId, productId, quantity) as { success: boolean; data?: unknown };
       if (response.success) {
-        setItems(response.data || []);
+        setItems((response.data as CartItem[]) || []);
       }
     } catch (error) {
       console.error('Failed to update cart:', error);
@@ -109,9 +110,9 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
   const removeFromCart = async (productId: string) => {
     try {
       setIsLoading(true);
-      const response = await cartAPI.removeFromCart(sessionId, productId);
+      const response = await cartAPI.removeFromCart(sessionId, productId) as { success: boolean; data?: unknown };
       if (response.success) {
-        setItems(response.data || []);
+        setItems((response.data as CartItem[]) || []);
       }
     } catch (error) {
       console.error('Failed to remove from cart:', error);

--- a/frontend/src/pages/CapsulesPage.tsx
+++ b/frontend/src/pages/CapsulesPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Layout from '../components/Layout/Layout';
 import ProductList from '../components/Products/ProductList';
 import { productsAPI } from '../services/api';
-import { SuperpowerCapsule } from '../types';
+import type { SuperpowerCapsule } from '../types';
 
 const CapsulesPage: React.FC = () => {
   const [capsules, setCapsules] = useState<SuperpowerCapsule[]>([]);
@@ -17,9 +17,9 @@ const CapsulesPage: React.FC = () => {
   const loadCapsules = async () => {
     try {
       setIsLoading(true);
-      const response = await productsAPI.getCapsules();
+      const response = await productsAPI.getCapsules() as { success: boolean; data?: unknown };
       if (response.success) {
-        setCapsules(response.data);
+        setCapsules(response.data as SuperpowerCapsule[]);
       }
     } catch (error) {
       console.error('Failed to load capsules:', error);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import Layout from '../components/Layout/Layout';
 import ProductList from '../components/Products/ProductList';
 import { productsAPI } from '../services/api';
-import { SuperpowerCapsule, FuturisticMachine } from '../types';
+import type { SuperpowerCapsule, FuturisticMachine } from '../types';
 
 interface FeaturedProducts {
   capsules: SuperpowerCapsule[];
@@ -20,9 +20,9 @@ const HomePage: React.FC = () => {
 
   const loadFeaturedProducts = async () => {
     try {
-      const response = await productsAPI.getFeatured();
+      const response = await productsAPI.getFeatured() as { success: boolean; data?: unknown };
       if (response.success) {
-        setFeaturedProducts(response.data);
+        setFeaturedProducts(response.data as FeaturedProducts);
       }
     } catch (error) {
       console.error('Failed to load featured products:', error);

--- a/frontend/src/pages/MachinesPage.tsx
+++ b/frontend/src/pages/MachinesPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Layout from '../components/Layout/Layout';
 import ProductList from '../components/Products/ProductList';
 import { productsAPI } from '../services/api';
-import { FuturisticMachine } from '../types';
+import type { FuturisticMachine } from '../types';
 
 const MachinesPage: React.FC = () => {
   const [machines, setMachines] = useState<FuturisticMachine[]>([]);
@@ -17,9 +17,9 @@ const MachinesPage: React.FC = () => {
   const loadMachines = async () => {
     try {
       setIsLoading(true);
-      const response = await productsAPI.getMachines();
+      const response = await productsAPI.getMachines() as { success: boolean; data?: unknown };
       if (response.success) {
-        setMachines(response.data);
+        setMachines(response.data as FuturisticMachine[]);
       }
     } catch (error) {
       console.error('Failed to load machines:', error);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import { RegisterUserData } from '../contexts/AuthContext';
-import { SuperpowerCapsule, FuturisticMachine } from '../types';
+import type { RegisterUserData } from '../contexts/AuthContext';
+import type { SuperpowerCapsule, FuturisticMachine } from '../types';
 
 interface OrderData {
   sessionId: string;
@@ -29,7 +29,7 @@ export const api = axios.create({
 // Add token to requests if available
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('authToken');
-  if (token) {
+  if (token && config.headers) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;


### PR DESCRIPTION
## Summary
- Resolve runtime TypeScript module import errors caused by `verbatimModuleSyntax: true` configuration
- Convert all interface/type imports to use proper `import type` syntax
- Fix union type property access issues with type assertions
- Resolve React component type import problems

## Changes Made
- ✅ Convert all interface/type imports to use `import type { ... }` syntax
- ✅ Fix union type property access with proper type assertions (e.g., `(product as SuperpowerCapsule).rarity`)
- ✅ Resolve ReactNode import issues in components by separating type imports
- ✅ Remove non-existent `_id` property references throughout codebase
- ✅ Fix loadCart function declaration order in CartContext to prevent "used before initialization" errors
- ✅ Add proper API response type handling with safe type casting
- ✅ Ensure compatibility with TypeScript `verbatimModuleSyntax: true` setting

## Problem Solved
This fixes the runtime error:
```
Uncaught SyntaxError: The requested module 'http://localhost:5173/src/types/index.ts' doesn't provide an export named: 'FuturisticMachine'
```

And the runtime error:
```
Uncaught ReferenceError: can't access lexical declaration 'loadCart' before initialization
```

## Test Plan
- [x] ✅ Frontend builds successfully without TypeScript errors
- [x] ✅ Frontend linting passes (only Vite dependency warnings remain)
- [x] ✅ Development server runs without module import errors
- [x] ✅ Site loads correctly without console errors
- [x] ✅ All components render properly with union types

## Technical Details
The TypeScript `verbatimModuleSyntax: true` configuration requires strict separation between type and value imports. This PR ensures all interface/type imports use the `import type` syntax while preserving runtime functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)